### PR TITLE
Horizontal Scroll BarFix

### DIFF
--- a/sass/styles.scss
+++ b/sass/styles.scss
@@ -33,6 +33,7 @@ body, html {
 	position: relative;
 	line-height: 1.45em;
 	-webkit-font-smoothing: antialiased;
+	overflow-x: hidden;
 
 }
 


### PR DESCRIPTION
Addition of CSS rule to fix horizontal scrolling bar appearing due to lack of overflow-x: hidden; in the body and html elements.

Issue preview:

![codingtrain](https://cloud.githubusercontent.com/assets/5782262/23810082/f2848220-0584-11e7-8d12-d39a26d45db6.PNG)